### PR TITLE
Add player dead state

### DIFF
--- a/game/player/dead.go
+++ b/game/player/dead.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ state = (*deadState)(nil)
-var TombstoneImageDuration = (500 * time.Millisecond).Nanoseconds()
+var TombstoneImageDuration = (3 * time.Second).Nanoseconds()
 
 type deadState struct {
 	*sharedState

--- a/game/player/dead.go
+++ b/game/player/dead.go
@@ -1,0 +1,42 @@
+package player
+
+import (
+	"candy/game/direction"
+	"candy/graphics"
+	"candy/input"
+	"time"
+)
+
+var _ state = (*deadState)(nil)
+var TombstoneImageDuration = (500 * time.Millisecond).Nanoseconds()
+
+type deadState struct {
+	*sharedState
+	tombstone *Tombstone
+	lag       int64
+}
+
+func (d *deadState) handleInput(in input.Input) state {
+	return d
+}
+
+func (d deadState) draw(batch graphics.Batch) {
+	if d.lag <= TombstoneImageDuration {
+		d.tombstone.draw(batch, d.x+d.playerWidth/2-d.tombstone.width/2, d.y, d.y)
+	}
+}
+
+func (d *deadState) update(timeElapsed time.Duration) state {
+	d.lag += timeElapsed.Nanoseconds()
+	return d
+}
+
+func newDeadState(state *sharedState) *deadState {
+	ts := newTombstone()
+	state.direction = direction.Down
+	return &deadState{
+		sharedState: state,
+		tombstone:   &ts,
+		lag:         0,
+	}
+}

--- a/game/player/player.go
+++ b/game/player/player.go
@@ -46,7 +46,9 @@ func (p Player) Draw(batch graphics.Batch) {
 		// TODO: player.state.getHeight() should rename to getDepth()
 		// TODO: square.Width need to be replaced with new getHeight()
 		markerY := p.state.getY() + square.Width + marker.YOffset
-		p.marker.Draw(batch, markerX, markerY, p.state.getY()+jellyZOffset-1)
+		if p.state.shouldShowMarker() {
+			p.marker.Draw(batch, markerX, markerY, p.state.getY()+jellyZOffset-1)
+		}
 	}
 }
 
@@ -58,8 +60,8 @@ func (p *Player) HandleInput(in input.Input) {
 	p.state = p.state.handleInput(in)
 }
 
-func (p Player) Update(timeElapsed time.Duration) {
-	p.state.update(timeElapsed)
+func (p *Player) Update(timeElapsed time.Duration) {
+	p.state = p.state.update(timeElapsed)
 	if p.marker != nil {
 		p.marker.Update(timeElapsed)
 	}

--- a/game/player/standing.go
+++ b/game/player/standing.go
@@ -5,6 +5,7 @@ import (
 	"candy/game/square"
 	"candy/input"
 	"candy/pubsub"
+	"time"
 )
 
 var _ state = (*standingState)(nil)
@@ -13,7 +14,11 @@ type standingState struct {
 	*sharedState
 }
 
-func (s standingState) handleInput(in input.Input) state {
+func (s *standingState) update(timeElapsed time.Duration) state {
+	return s
+}
+
+func (s *standingState) handleInput(in input.Input) state {
 	switch in.Action {
 	case input.Press:
 		switch in.Device {
@@ -44,8 +49,8 @@ func newStandingStateOnSquare(
 	regionOffset regionOffset,
 	character character,
 	pubSub *pubsub.PubSub,
-) standingState {
-	return standingState{
+) *standingState {
+	return &standingState{
 		&sharedState{
 			dropCandyChecker: dropCandyChecker,
 			moveChecker:      moveChecker,
@@ -62,6 +67,7 @@ func newStandingStateOnSquare(
 			availableCandy:   character.initialCandyLimit,
 			character:        character,
 			pubSub:           pubSub,
+			showMarker:       true,
 		},
 	}
 }

--- a/game/player/state.go
+++ b/game/player/state.go
@@ -12,7 +12,7 @@ import (
 
 type state interface {
 	handleInput(in input.Input) state
-	update(timeElapsed time.Duration)
+	update(timeElapsed time.Duration) state
 	draw(batch graphics.Batch)
 	trapped() state
 	getX() int
@@ -24,6 +24,7 @@ type state interface {
 	incrementAvailableCandy()
 	increaseCandyLimit(amountIncrease int)
 	isNormal() bool
+	shouldShowMarker() bool
 }
 
 type sharedState struct {
@@ -33,6 +34,7 @@ type sharedState struct {
 	playerHeight     int
 	x                int
 	y                int
+	remainingTime    time.Duration
 	dropCandyChecker DropCandyChecker
 	moveChecker      MoveChecker
 	regionOffset     regionOffset
@@ -42,10 +44,7 @@ type sharedState struct {
 	candyLimit       int
 	character        character
 	pubSub           *pubsub.PubSub
-}
-
-func (s sharedState) update(timeElapsed time.Duration) {
-	return
+	showMarker       bool
 }
 
 func (s sharedState) isNormal() bool {
@@ -97,6 +96,10 @@ func (s *sharedState) incrementAvailableCandy() {
 	if s.availableCandy < s.candyLimit {
 		s.availableCandy++
 	}
+}
+
+func (s *sharedState) shouldShowMarker() bool {
+	return s.showMarker
 }
 
 func (s *sharedState) dropCandy() {

--- a/game/player/tombstone.go
+++ b/game/player/tombstone.go
@@ -1,0 +1,32 @@
+package player
+
+import (
+	"candy/graphics"
+)
+
+type Tombstone struct {
+	lag        int64
+	width      int
+	imageBound graphics.Bound
+}
+
+func (ts Tombstone) getWidth() int {
+	return ts.width
+}
+func (ts Tombstone) draw(batch graphics.Batch, x int, y int, z int) {
+	bound := ts.imageBound
+	batch.DrawSprite(x, y, z, bound, 1)
+}
+
+func newTombstone() Tombstone {
+	return Tombstone{
+		lag:   0,
+		width: 60,
+		imageBound: graphics.Bound{
+			X:      960,
+			Y:      933,
+			Width:  54,
+			Height: 77,
+		},
+	}
+}

--- a/game/player/trapped.go
+++ b/game/player/trapped.go
@@ -8,19 +8,22 @@ import (
 	"candy/input"
 )
 
+var trapTimeOut = (5 * time.Second).Nanoseconds()
+
 var _ state = (*trappedState)(nil)
 
 type trappedState struct {
 	*sharedState
 	jelly         *Jelly
 	prevDirection direction.Direction
+	trappedLag    int64
 }
 
 func (t trappedState) isNormal() bool {
 	return false
 }
 
-func (t *trappedState) handleInput(in input.Input) state {
+func (t *trappedState) handleInput(_ input.Input) state {
 	return t
 }
 
@@ -29,9 +32,15 @@ func (t trappedState) draw(batch graphics.Batch) {
 	t.jelly.draw(batch, t.x+t.playerWidth/2-t.jelly.width/2, t.y, t.y+jellyZOffset)
 }
 
-func (t trappedState) update(timeElapsed time.Duration) {
-	t.sharedState.update(timeElapsed)
+func (t *trappedState) update(timeElapsed time.Duration) state {
+	t.trappedLag += timeElapsed.Nanoseconds()
+	if t.trappedLag >= trapTimeOut {
+		t.showMarker = false
+		return newDeadState(t.sharedState)
+	}
+
 	t.jelly.update(timeElapsed)
+	return t
 }
 
 func newTrapState(state *sharedState) *trappedState {
@@ -42,5 +51,6 @@ func newTrapState(state *sharedState) *trappedState {
 		sharedState:   state,
 		jelly:         &jl,
 		prevDirection: prevDirection,
+		trappedLag:    0,
 	}
 }

--- a/game/player/walking.go
+++ b/game/player/walking.go
@@ -19,12 +19,13 @@ type walkingState struct {
 	lag int64
 }
 
-func (w *walkingState) update(timeElapsed time.Duration) {
+func (w *walkingState) update(timeElapsed time.Duration) state {
 	w.lag += timeElapsed.Nanoseconds()
 	steps := int(w.lag / nanoPerStep)
 	w.sharedState.currStep = nextStep(w.sharedState.currStep, steps)
 
 	w.lag %= nanoPerStep
+	return w
 }
 
 func (w walkingState) handleInput(in input.Input) state {

--- a/screen/game.go
+++ b/screen/game.go
@@ -181,7 +181,7 @@ func NewGame(
 	pubSub.Subscribe(pubsub.OnCandyStartExploding, func(payload interface{}) {
 		playerID := payload.(int)
 		gm.incrementAvailableCandy(playerID)
-
 	})
+
 	return &gm
 }


### PR DESCRIPTION
### Screenshots
![image](https://user-images.githubusercontent.com/76569613/113263266-66a08180-9286-11eb-8cc4-b0dc11ed08da.png)

### High Level
This PR is to move a player to a dead state when the he/she is trapped in the jelly for more than 5 seconds. 

### Detailed Explanation
Per game rule, a player can die and be removed from the game after being trapped for 5 seconds. I did 3 things: 

1) added a dead state for the player, drawing a tombstone after a player is dead. 

2) removed marker when the player is in the dead state

3) removed tombstone from the game after 0.5 seconds

